### PR TITLE
MEN-3040: Defined a single-artifact-file workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+create-artifact-worker

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,8 @@ RUN mkdir -p /usr/share/mender/modules/v3 && wget -N -P /usr/share/mender/module
 RUN wget https://raw.githubusercontent.com/mendersoftware/mender/master/support/modules-artifact-gen/single-file-artifact-gen -O /usr/bin/single-file-artifact-gen
 RUN chmod +x /usr/bin/single-file-artifact-gen
 
+COPY ./workflows/single-file-artifact.json /etc/workflows/definitions/single-file-artifact.json
+
 COPY ./config.yaml /etc/workflows
 COPY --from=builder /go/src/github.com/mendersoftware/create-artifact-worker/create-artifact /usr/bin
 ENTRYPOINT ["/usr/bin/workflows", "--config", "/etc/workflows/config.yaml", "worker"]

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,5 @@
+
+# Workflows path
+# The path where the workflows definitions are installed
+# Defaults to: "/etc/workflows/definitions"
+workflows_path: "/etc/workflows/definitions"

--- a/workflows/single-file-artifact.json
+++ b/workflows/single-file-artifact.json
@@ -1,0 +1,38 @@
+{
+    "name": "Single-file updates workflow",
+    "description": "Runs a single CLI command -- An invocation of the create_artifact CLI",
+    "version": 1,
+    "tasks": [
+        {
+            "name": "Run create_artifact CLI",
+            "type": "cli",
+            "cli": {
+                "command": [
+                    "create-artifact-worker",
+                    "single-file",
+                    "--artifact-id", "${workflow.input.artifact_id}",
+                    "--artifact-name", "${workflow.input.artifact_name}",
+                    "--delete-artifact-uri", "${workflow.input.delete_artifact_uri}",
+                    "--description", "${workflow.input.description}",
+                    "--device-type", "${workflow.input.device_type}",
+                    "--get-artifact-uri", "${workflow.input.get_artifact_uri}",
+                    "--tenant-id", "${workflow.input.tenant_id}",
+                    "--token", "${workflow.input.token}",
+                    "--args", "${workflow.input.args}",
+                ],
+                "executionTimeOut": 100,
+            }
+        }
+    ],
+    "inputParameters": [
+        "artifact_id",
+        "artifact_name",
+        "delete_artifact_uri",
+        "description",
+        "device_type",
+        "get_artifact_uri",
+        "tenant_id",
+        "token",
+        "args",
+    ],
+}


### PR DESCRIPTION
This adds a workflow for the 'workflows' microservices which runs a CLI workflow
in order to create the single-file-update Artifact.

Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>