### PR TITLE
remove unused env vars

### DIFF
--- a/cmd/single-file.go
+++ b/cmd/single-file.go
@@ -52,10 +52,8 @@ var singleFileCmd = &cobra.Command{
 	Use:   "single-file",
 	Short: "Generate an update using a single-file update module.",
 	Long: "\nBesides command line args, supports the following env vars:\n\n" +
-		"CREATE_ARTIFACT_SERVER root server url (required)\n" +
 		"CREATE_ARTIFACT_SKIPVERIFY skip ssl verification (default: false)\n" +
 		"CREATE_ARTIFACT_WORKDIR working dir for processing (default: /var)\n" +
-		"CREATE_ARTIFACT_GATEWAY_URL public-facing gateway url\n" +
 		"CREATE_ARTIFACT_DEPLOYMENTS_URL internal deployments service url\n",
 	Run: func(cmd *cobra.Command, args []string) {
 		c, err := NewSingleFileCmd(cmd, args)
@@ -132,7 +130,6 @@ func NewSingleFileCmd(cmd *cobra.Command, args []string) (*SingleFileCmd, error)
 }
 
 func (c *SingleFileCmd) init(cmd *cobra.Command) error {
-	c.ServerUrl = viper.GetString(config.CfgServer)
 	c.DeploymentsUrl = viper.GetString(config.CfgDeploymentsUrl)
 	c.SkipVerify = viper.GetBool(config.CfgSkipVerify)
 	c.Workdir = viper.GetString(config.CfgWorkDir)
@@ -197,10 +194,6 @@ func (c *SingleFileCmd) init(cmd *cobra.Command) error {
 }
 
 func (c *SingleFileCmd) Validate() error {
-	if err := config.ValidUrl(c.ServerUrl); err != nil {
-		return errors.Wrap(err, "invalid gateway address")
-	}
-
 	if err := config.ValidAbsPath(c.Workdir); err != nil {
 		return errors.Wrap(err, "invalid workdir")
 	}
@@ -230,7 +223,7 @@ func (c *SingleFileCmd) Run() error {
 	mlog.Info("running single-file update module generation:\n%s", c.dumpArgs())
 	mlog.Info("config:\n%s", config.Dump())
 
-	cd, err := client.NewDeployments(c.ServerUrl, c.DeploymentsUrl, c.SkipVerify)
+	cd, err := client.NewDeployments(c.DeploymentsUrl, c.SkipVerify)
 	if err != nil {
 		return errors.New("failed to configure 'deployments' client")
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -24,7 +24,6 @@ import (
 
 const (
 	//translate to env vars: CREATE_ARTIFACT_<CAPITALIZED>
-	CfgServer         = "server"
 	CfgSkipVerify     = "skipverify"
 	CfgVerbose        = "verbose"
 	CfgWorkDir        = "workdir"
@@ -36,7 +35,6 @@ func Init() {
 	viper.SetEnvPrefix("CREATE_ARTIFACT")
 	viper.AutomaticEnv()
 
-	viper.SetDefault(CfgServer, "")
 	viper.SetDefault(CfgSkipVerify, false)
 	viper.SetDefault(CfgVerbose, false)
 	viper.SetDefault(CfgWorkDir, "/var")
@@ -64,8 +62,7 @@ func ValidAbsPath(s string) error {
 }
 
 func Dump() string {
-	return dump(CfgServer) +
-		dump(CfgSkipVerify) +
+	return dump(CfgSkipVerify) +
 		dump(CfgVerbose) +
 		dump(CfgWorkDir) +
 		dump(CfgDeploymentsUrl) +


### PR DESCRIPTION
the gateway url is a leftover from an early iteration which
pinged the public deployments api. now we use direct s3 urls so
all bits concerning that are now removed.

also, we had 2 names for this setting (gateway_url/server_url), remove
that too.

changelog: none

Signed-off-by: Marcin Chalczynski <m.chalczynski@gmail.com>