### PR TITLE
Add missing license in LIC_FILES_CHKSUM.sha256

### DIFF
--- a/LIC_FILES_CHKSUM.sha256
+++ b/LIC_FILES_CHKSUM.sha256
@@ -22,4 +22,4 @@ f6918bd93ffe07f4b2c61b8287c32cb3122e08aed0be50f1c7d0eddc87877a8f  vendor/gopkg.i
 dad2b0b2cc2dbdbf95ad5d800ef7588956e74dc2479014829d42be295125c25d  vendor/github.com/stretchr/testify/LICENSE
 2eb550be6801c1ea434feba53bf6d12e7c71c90253e0a9de4a4f46cf88b56477  vendor/github.com/pmezard/go-difflib/LICENSE
 1b93a317849ee09d3d7e4f1d20c2b78ddb230b4becb12d7c224c927b9d470251  vendor/github.com/davecgh/go-spew/LICENSE
-
+8d427fd87bc9579ea368fde3d49f9ca22eac857f91a9dec7e3004bdfab7dee86  vendor/github.com/pkg/errors/LICENSE

--- a/license_test.go
+++ b/license_test.go
@@ -14,9 +14,12 @@
 
 package main
 
-import "testing"
-import mt "github.com/mendersoftware/mendertesting"
+import (
+	mt "github.com/mendersoftware/mendertesting"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
 
 func TestLicenses(t *testing.T) {
-	mt.CheckMenderCompliance(t)
+	assert.NoError(t, mt.CheckMenderCompliance(t))
 }


### PR DESCRIPTION
The actual license check is also broken (here and in many other repos).
It will be followed up separately.