### PR TITLE
Limit the workflows create-artifact-worker can process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,4 @@ COPY ./workflows/generate_artifact.json /etc/workflows/definitions/generate_arti
 
 COPY ./config.yaml /etc/workflows
 COPY --from=builder /go/src/github.com/mendersoftware/create-artifact-worker/create-artifact /usr/bin
-ENTRYPOINT ["/usr/bin/workflows", "--config", "/etc/workflows/config.yaml", "worker"]
+ENTRYPOINT ["/usr/bin/workflows", "--config", "/etc/workflows/config.yaml", "worker", "--workflows", "generate_artifact"]


### PR DESCRIPTION
workflows-worker and create-artifact-worker are both workflows worker,
the first generic, the latter specialized. To avoid processing the
generate_artifact workflows with the generic workflow worker, we need to
use the `--workflows` CLI options when starting the docker container.