### PR TITLE
removed deprecated ci job image overrides to align with ci templates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,3 @@ include:
     file: '.gitlab-ci-check-docker-build.yml'
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-github-status-updates.yml'
-
-test:unit:
-  image: golang:1.13


### PR DESCRIPTION
Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>

cherry-pick didn't apply cleanly, thus the extra review request @lluiscampos