### PR TITLE
MEN-5871: Allow DELETE endpoint to return 202 accepted

### DIFF
--- a/client/s3.go
+++ b/client/s3.go
@@ -1,16 +1,16 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
-//    Licensed under the Apache License, Version 2.0 (the "License");
-//    you may not use this file except in compliance with the License.
-//    You may obtain a copy of the License at
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
 //
-//        http://www.apache.org/licenses/LICENSE-2.0
+//	    http://www.apache.org/licenses/LICENSE-2.0
 //
-//    Unless required by applicable law or agreed to in writing, software
-//    distributed under the License is distributed on an "AS IS" BASIS,
-//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//    See the License for the specific language governing permissions and
-//    limitations under the License.
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
 package client
 
 import (
@@ -112,7 +112,7 @@ func (s *storage) Delete(ctx context.Context, url string) error {
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusNoContent {
+	if res.StatusCode != http.StatusNoContent && res.StatusCode != http.StatusAccepted {
 		var body string
 
 		bbody, err := ioutil.ReadAll(res.Body)

--- a/log/log.go
+++ b/log/log.go
@@ -1,16 +1,16 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
-//    Licensed under the Apache License, Version 2.0 (the "License");
-//    you may not use this file except in compliance with the License.
-//    You may obtain a copy of the License at
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
 //
-//        http://www.apache.org/licenses/LICENSE-2.0
+//	    http://www.apache.org/licenses/LICENSE-2.0
 //
-//    Unless required by applicable law or agreed to in writing, software
-//    distributed under the License is distributed on an "AS IS" BASIS,
-//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//    See the License for the specific language governing permissions and
-//    limitations under the License.
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
 package log
 
 import (
@@ -23,16 +23,16 @@ func Init(verbose bool) {
 	isVerbose = verbose
 }
 
-func Error(fmt string, args ...string) {
-	log.Printf("ERROR "+fmt+"\n", args)
+func Error(fmt string, args ...interface{}) {
+	log.Printf("ERROR "+fmt+"\n", args...)
 }
 
-func Info(fmt string, args ...string) {
-	log.Printf(fmt+"\n", args)
+func Info(fmt string, args ...interface{}) {
+	log.Printf(fmt+"\n", args...)
 }
 
-func Verbose(fmt string, args ...string) {
+func Verbose(fmt string, args ...interface{}) {
 	if isVerbose {
-		log.Printf(" -- "+fmt+"\n", args)
+		log.Printf(" -- "+fmt+"\n", args...)
 	}
 }


### PR DESCRIPTION
The Azure Blob Storage DELETE API returns 202 instead of 204 on success. This breaks the current implementation.
I also took the liberty of cleaning up some very confusing log messages (URLs with escape sequences were decoded as formatting directives).