### PR TITLE
chore: Upgraded to golang:1.20.10-alpine3.18 for builder in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ FROM mendersoftware/workflows:$WORKFLOWS_VERSION as workflows
 
 FROM alpine:3.18.4
 ARG MENDER_ARTIFACT_VERSION
-RUN apk add --no-cache \ 
+RUN apk add --no-cache \
     xz \
     libc6-compat \
     openssl1.1-compat \
@@ -28,7 +28,7 @@ RUN apk add --no-cache \
     pigz \
     dosfstools \
     wget \
-    make \ 
+    make \
     bash
     # bmap-tools not found
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG WORKFLOWS_VERSION=master
 ARG MENDER_ARTIFACT_VERSION=3.10.1
 
-FROM golang:1.20.4-alpine3.16 as builder
+FROM golang:1.20.10-alpine3.18 as builder
 RUN apk add --no-cache \
     ca-certificates \
     musl-dev \


### PR DESCRIPTION
- chore: Upgraded to golang:1.20.10-alpine3.18 for builder in Dockerfile
- chore: Removed trailing whitespace in Dockerfile
