### PR TITLE
SEC-1635: Update `mender-artifact` binary to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ FROM mendersoftware/workflows:$WORKFLOWS_VERSION as workflows
 
 FROM --platform=$BUILDPLATFORM alpine:3.18.4 as mender-artifact-get
 ARG TARGETARCH
-ARG MENDER_ARTIFACT_VERSION=3.10.1
+ARG MENDER_ARTIFACT_VERSION=4.1.0
 RUN apk --update --no-cache add binutils
 RUN deb_filename=mender-artifact_${MENDER_ARTIFACT_VERSION}-1%2Bdebian%2Bbullseye_${TARGETARCH}.deb && \
     wget "https://downloads.mender.io/repos/debian/pool/main/m/mender-artifact/${deb_filename}" \


### PR DESCRIPTION
Changelog: Update `mender-artifact` binary used in the container to the latest available to mitigate a set of CVEs in the Go standard library.